### PR TITLE
Add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# Deprecation notice
+
+This module is no longer being upgraded or maintained. We recommend you use
+[terraform-aws-iam-sleuth](https://github.com/trussworks/terraform-aws-iam-sleuth)
+instead.
+
 Creates an AWS Lambda function to check that IAM Access Keys are not older than 90 days
 on a scheduled interval using [truss-aws-tools](https://github.com/trussworks/truss-aws-tools).
 


### PR DESCRIPTION
I learned in :lock: [this](https://trussworks.slack.com/archives/CLNC1MUBS/p1599235257291000) slack thread that we're deprecating this in favor of the iam-sleuth. This PR adds a deprecation notice to the README. After it is merged in, I will archive the repo.